### PR TITLE
reduce gas price

### DIFF
--- a/motif/rules.go
+++ b/motif/rules.go
@@ -165,7 +165,7 @@ func DefaultEconomyRules() EconomyRules {
 	return EconomyRules{
 		BlockMissedSlack: 50,
 		Gas:              DefaultGasRules(),
-		MinGasPrice:      big.NewInt(1e11),
+		MinGasPrice:      big.NewInt(1e10),
 		ShortGasPower:    DefaultShortGasPowerRules(),
 		LongGasPower:     DefaulLongGasPowerRules(),
 	}


### PR DESCRIPTION
gas price is too high for NFT creations when compared with potential price of 9M Motif tokens. If we consider the use of Blockchain for mass product tagging, this may cause real problems if Motif Token price stays higher than expected (5-10x more than presale price).  Reduce the minimum gas by 10 and redeploy mainnet to eliminate any future complications.